### PR TITLE
Add HttpHeadersRequestAuthenticator

### DIFF
--- a/src/main/java/org/entur/gbfs/authentication/HttpHeadersRequestAuthenticator.java
+++ b/src/main/java/org/entur/gbfs/authentication/HttpHeadersRequestAuthenticator.java
@@ -1,0 +1,19 @@
+package org.entur.gbfs.authentication;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpHeadersRequestAuthenticator implements RequestAuthenticator {
+    private final Map<String, String> headersToSet;
+
+    public HttpHeadersRequestAuthenticator(Map<String, String> headers) {
+        this.headersToSet = new HashMap(headers);
+    }
+
+    @Override
+    public void authenticateRequest(Map<String, String> httpHeaders) throws RequestAuthenticationException {
+        for (String key : headersToSet.keySet()) {
+            httpHeaders.put(key, headersToSet.get(key));
+        }
+    }
+}

--- a/src/test/java/org/entur/gbfs/authentication/HttpHeadersRequestAuthenticatorTest.java
+++ b/src/test/java/org/entur/gbfs/authentication/HttpHeadersRequestAuthenticatorTest.java
@@ -1,0 +1,23 @@
+package org.entur.gbfs.authentication;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+class HttpHeadersRequestAuthenticatorTest {
+    @Test
+    void testHttpHeadersRequestAuthenticator() {
+        String HTTP_HEADER_KEY = "x-api-key";
+        String HTTP_HEADER_VALUE = "xyz";
+        Map<String, String> FAKE_HEADERS = Collections.singletonMap(HTTP_HEADER_KEY, HTTP_HEADER_VALUE);
+
+        RequestAuthenticator requestAuthenticator = new HttpHeadersRequestAuthenticator(FAKE_HEADERS);
+        Map<String, String> headers = new HashMap<>();
+        requestAuthenticator.authenticateRequest(headers);
+
+        Assertions.assertEquals(HTTP_HEADER_VALUE, headers.get(HTTP_HEADER_KEY));
+    }
+}


### PR DESCRIPTION
This PR adds a HttpHeadersRequestAuthenticator.

It's implementation is pretty close to the `BearerTokenRequestAuthenticator`, but allows custom header / value, as some providers have a proprietary authentication scheme.