### PR TITLE
Add support for system proxy

### DIFF
--- a/src/main/java/org/entur/gbfs/HttpUtils.java
+++ b/src/main/java/org/entur/gbfs/HttpUtils.java
@@ -8,6 +8,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.config.SocketConfig;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,6 +86,7 @@ public class HttpUtils {
 
     private static HttpClient getClient(long timeoutConnection, long timeoutSocket) {
         return HttpClientBuilder.create()
+                .setRoutePlanner(new SystemDefaultRoutePlanner(null))
                 .setDefaultSocketConfig(SocketConfig.custom().setSoTimeout((int)timeoutSocket).build())
                 .setConnectionTimeToLive(timeoutConnection, TimeUnit.MILLISECONDS)
                 .build();


### PR DESCRIPTION
This PR sets the `SystemDefaultRoutePlanner` on the `HttpClient`, so that an `httpProxy` can (but needs not to) be provided via e.g. `-Dhttp.proxyHost=localhost -Dhttp.proxyPort=8080`.