### PR TITLE
Add optional oauth2 scope

### DIFF
--- a/src/main/java/org/entur/gbfs/authentication/Oauth2ClientCredentialsGrantRequestAuthenticator.java
+++ b/src/main/java/org/entur/gbfs/authentication/Oauth2ClientCredentialsGrantRequestAuthenticator.java
@@ -4,14 +4,9 @@ import java.net.URI;
 import java.util.Map;
 import org.dmfs.httpessentials.client.HttpRequestExecutor;
 import org.dmfs.httpessentials.httpurlconnection.HttpUrlConnectionExecutor;
-import org.dmfs.oauth2.client.BasicOAuth2AuthorizationProvider;
-import org.dmfs.oauth2.client.BasicOAuth2Client;
-import org.dmfs.oauth2.client.BasicOAuth2ClientCredentials;
-import org.dmfs.oauth2.client.OAuth2AccessToken;
-import org.dmfs.oauth2.client.OAuth2AuthorizationProvider;
-import org.dmfs.oauth2.client.OAuth2Client;
-import org.dmfs.oauth2.client.OAuth2ClientCredentials;
+import org.dmfs.oauth2.client.*;
 import org.dmfs.oauth2.client.grants.ClientCredentialsGrant;
+import org.dmfs.oauth2.client.scope.BasicScope;
 import org.dmfs.oauth2.client.scope.EmptyScope;
 import org.dmfs.rfc3986.uris.EmptyUri;
 import org.dmfs.rfc5545.DateTime;
@@ -22,12 +17,22 @@ public class Oauth2ClientCredentialsGrantRequestAuthenticator
 
   private final HttpRequestExecutor executor = new HttpUrlConnectionExecutor();
   private final OAuth2Client client;
+  private final OAuth2Scope scope;
   private OAuth2AccessToken token;
 
   public Oauth2ClientCredentialsGrantRequestAuthenticator(
     URI tokenUrl,
     String clientId,
     String clientPassword
+  ) {
+    this(tokenUrl, clientId, clientPassword, null);
+  }
+
+  public Oauth2ClientCredentialsGrantRequestAuthenticator(
+    URI tokenUrl,
+    String clientId,
+    String clientPassword,
+    String scope
   ) {
     OAuth2AuthorizationProvider provider = new BasicOAuth2AuthorizationProvider(
       null,
@@ -41,6 +46,8 @@ public class Oauth2ClientCredentialsGrantRequestAuthenticator
     );
 
     client = new BasicOAuth2Client(provider, credentials, EmptyUri.INSTANCE);
+
+    this.scope = scope == null ? EmptyScope.INSTANCE : new BasicScope(scope);
   }
 
   @Override
@@ -48,8 +55,7 @@ public class Oauth2ClientCredentialsGrantRequestAuthenticator
     throws RequestAuthenticationException {
     try {
       if (token == null || token.expirationDate().after(DateTime.now())) {
-        token =
-          new ClientCredentialsGrant(client, EmptyScope.INSTANCE).accessToken(executor);
+        token = new ClientCredentialsGrant(client, scope).accessToken(executor);
       }
       httpHeaders.put("Authorization", String.format("Bearer %s", token.accessToken()));
     } catch (Exception e) {

--- a/src/test/java/org/entur/gbfs/authentication/Oauth2ClientCredentialsGrantRequestAuthenticatorTest.java
+++ b/src/test/java/org/entur/gbfs/authentication/Oauth2ClientCredentialsGrantRequestAuthenticatorTest.java
@@ -1,8 +1,6 @@
 package org.entur.gbfs.authentication;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
@@ -20,12 +18,21 @@ class Oauth2ClientCredentialsGrantRequestAuthenticatorTest {
     WireMockRuntimeInfo runtimeInfo
   ) {
     String TEST_TOKEN_URL = "http://localhost:" + runtimeInfo.getHttpPort() + "/token";
-    stubFor(post("/token").willReturn(okJson("{\"access_token\":\"fake_token\"}")));
+    String TEST_USER = "foo";
+    String TEST_PASSWORD = "bar";
+
+    stubFor(
+      post("/token")
+        .withRequestBody(equalTo("grant_type=client_credentials&scope=test-scope"))
+        .withBasicAuth(TEST_USER, TEST_PASSWORD)
+        .willReturn(okJson("{\"access_token\":\"fake_token\"}"))
+    );
     Oauth2ClientCredentialsGrantRequestAuthenticator authenticator =
       new Oauth2ClientCredentialsGrantRequestAuthenticator(
         URI.create(TEST_TOKEN_URL),
-        "foo",
-        "bar"
+        TEST_USER,
+        TEST_PASSWORD,
+        "test-scope"
       );
     Map<String, String> headers = new HashMap<>();
     authenticator.authenticateRequest(headers);


### PR DESCRIPTION
This PR adds an optional scope parameter to `Oauth2ClientCredentialsGrantRequestAuthenticator`.

The unit test `Oauth2ClientCredentialsGrantRequestAuthenticatorTest` is extended to assert that the scope is sent as intended.

Code for both classes is reformatted with prettier (see #117)

