### PR TITLE
Exponential decay when requests fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.entur.gbfs</groupId>
     <artifactId>gbfs-loader-java</artifactId>
-    <version>2.0.20-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>gbfs-loader-java</name>
     <description>Manage loading of GBFS feeds</description>

--- a/src/main/java/org/entur/gbfs/GbfsLoader.java
+++ b/src/main/java/org/entur/gbfs/GbfsLoader.java
@@ -249,16 +249,19 @@ public class GbfsLoader {
 
     boolean didUpdate = false;
     if (updateLock.tryLock()) {
-      for (GBFSFeedUpdater<?> updater : feedUpdaters.values()) {
-        if (updater.shouldUpdate()) {
-          updater.fetchData();
-          // TODO didUpdate is set to true, once for one feed an update was initiated,
-          // no matter if successful or not(?)
-          didUpdate = true;
+      try {
+        for (GBFSFeedUpdater<?> updater : feedUpdaters.values()) {
+          if (updater.shouldUpdate()) {
+            updater.fetchData();
+            // TODO didUpdate is set to true, once for one feed an update was initiated,
+            // no matter if successful or not(?)
+            didUpdate = true;
+          }
         }
+      } finally {
+        // be sure to release lock, even in case an exception is thrown
+        updateLock.unlock();
       }
-      // TODO Is really no exception ever thrown so we can ignore the try/finally idiom here?
-      updateLock.unlock();
     }
     return didUpdate;
   }

--- a/src/test/java/org/entur/gbfs/GbfsLoaderTest.java
+++ b/src/test/java/org/entur/gbfs/GbfsLoaderTest.java
@@ -54,6 +54,23 @@ public class GbfsLoaderTest {
   }
 
   @Test
+  void testBackoffStrategy() {
+    GbfsLoader loader = new GbfsLoader(
+      "file:src/test/resources/gbfs/feedwith404feeds/gbfs.json",
+      LANGUAGE_NB
+    );
+    assertTrue(
+      loader.update(),
+      "First update should return true (even though not successful), as it was at " +
+      "least initiated"
+    );
+    assertFalse(
+      loader.update(),
+      "Should not update immediately after failing one, even though ttl is 0"
+    );
+  }
+
+  @Test
   void getV22FeedWithNoLanguage() {
     GbfsLoader loader = new GbfsLoader(
       "file:src/test/resources/gbfs/lillestrombysykkel/gbfs.json"

--- a/src/test/resources/gbfs/feedwith404feeds/gbfs.json
+++ b/src/test/resources/gbfs/feedwith404feeds/gbfs.json
@@ -1,0 +1,26 @@
+{
+  "last_updated": 1631517382,
+  "ttl": 0,
+  "data": {
+    "nb": {
+      "feeds": [
+        {
+          "name": "system_information",
+          "url": "file:src/test/resources/gbfs/feedwith404feeds/system_information.json"
+        },
+        {
+          "name": "station_information",
+          "url": "file:src/test/resources/gbfs/feedwith404feeds/station_information.json"
+        },
+        {
+          "name": "station_status",
+          "url": "file:src/test/resources/gbfs/feedwith404feeds/station_status.json"
+        },
+        {
+          "name": "free_bike_status",
+          "url": "file:src/test/resources/gbfs/feedwith404feeds/free_bike_status.json"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR addresses https://github.com/entur/lamassu/issues/340. It introduces an `UpdateStrategy` which schedules new requests depending on the number of previously failed request attempts, with a max delay of one hour.

To verify this behaviour, a unit tests is added, which asserts that immediately after a failing request the feed should not update. Note that this is a rather implicit blackbox test. I considered extracting  `UpdateStrategy` to a proper class instead of a private nested class to do a whitebox test, but refrained from this as `GBFSFeedUpdater` is a private inner class also.

Note further, that I came across two questions regarding the current implementation, which probably should be addressed in another PR (or need not, depending on the current reasoning). 