### PR TITLE
Fix: return discovery feed

### DIFF
--- a/src/main/java/org/entur/gbfs/loader/BaseGbfsLoader.java
+++ b/src/main/java/org/entur/gbfs/loader/BaseGbfsLoader.java
@@ -145,10 +145,16 @@ public abstract class BaseGbfsLoader<S, T> {
   }
 
   public Optional<byte[]> getRawFeed(S feedName) {
+    if (feedName == getDiscoveryFeedName()) {
+      return discoveryFileUpdater.getRawData();
+    }
+
     GBFSFeedUpdater<?> updater = feedUpdaters.get(feedName);
     if (updater == null) {
       return Optional.empty();
     }
     return updater.getRawData();
   }
+
+  protected abstract S getDiscoveryFeedName();
 }

--- a/src/main/java/org/entur/gbfs/loader/v2/GbfsV2Loader.java
+++ b/src/main/java/org/entur/gbfs/loader/v2/GbfsV2Loader.java
@@ -125,4 +125,9 @@ public class GbfsV2Loader extends BaseGbfsLoader<GBFSFeedName, GBFS> {
       )
       .collect(Collectors.toList());
   }
+
+  @Override
+  protected GBFSFeedName getDiscoveryFeedName() {
+    return GBFSFeedName.GBFS;
+  }
 }

--- a/src/main/java/org/entur/gbfs/loader/v3/GbfsV3Loader.java
+++ b/src/main/java/org/entur/gbfs/loader/v3/GbfsV3Loader.java
@@ -93,4 +93,9 @@ public class GbfsV3Loader extends BaseGbfsLoader<GBFSFeed.Name, GBFSGbfs> {
       )
       .collect(Collectors.toList());
   }
+
+  @Override
+  protected GBFSFeed.Name getDiscoveryFeedName() {
+    return GBFSFeed.Name.GBFS;
+  }
 }

--- a/src/test/java/org/entur/gbfs/loader/v2/GbfsV2LoaderTest.java
+++ b/src/test/java/org/entur/gbfs/loader/v2/GbfsV2LoaderTest.java
@@ -153,6 +153,8 @@ class GbfsV2LoaderTest {
     );
     assertEquals(0, validationResult.getErrorsCount());
 
+    assertFalse(loader.getRawFeed(GBFSFeedName.GBFS).isEmpty());
+
     GBFSSystemInformation systemInformation = loader.getFeed(GBFSSystemInformation.class);
     assertNotNull(systemInformation);
     assertEquals("lillestrombysykkel", systemInformation.getData().getSystemId());

--- a/src/test/java/org/entur/gbfs/loader/v3/GbfsV3LoaderTest.java
+++ b/src/test/java/org/entur/gbfs/loader/v3/GbfsV3LoaderTest.java
@@ -1,10 +1,6 @@
 package org.entur.gbfs.loader.v3;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
@@ -51,6 +47,8 @@ class GbfsV3LoaderTest {
       new ByteArrayInputStream(loader.getRawFeed(GBFSFeed.Name.SYSTEM_INFORMATION).get())
     );
     assertEquals(0, validationResult.getErrorsCount());
+
+    assertFalse(loader.getRawFeed(GBFSFeed.Name.GBFS).isEmpty());
 
     GBFSSystemInformation systemInformation = loader.getFeed(GBFSSystemInformation.class);
     assertNotNull(systemInformation);


### PR DESCRIPTION
This PR 
* adds a test case reproducing https://github.com/entur/lamassu/issues/430
* fixes https://github.com/entur/lamassu/issues/430 by returning the discovery feed as a raw feed also, re-establishing behavior that was accidentally removed in 1ab4111