### PR TITLE
Skip discovery files when return feeds for updaters

### DIFF
--- a/src/main/java/org/entur/gbfs/loader/v2/GbfsV2Loader.java
+++ b/src/main/java/org/entur/gbfs/loader/v2/GbfsV2Loader.java
@@ -120,6 +120,7 @@ public class GbfsV2Loader extends BaseGbfsLoader<GBFSFeedName, GBFS> {
     return feeds
       .getFeeds()
       .stream()
+      .filter(feed -> !feed.getName().equals(GBFSFeedName.GBFS))
       .map(feed ->
         new GbfsFeed<>(feed.getName(), feed.getName().implementingClass(), feed.getUrl())
       )

--- a/src/main/java/org/entur/gbfs/loader/v3/GbfsV3Loader.java
+++ b/src/main/java/org/entur/gbfs/loader/v3/GbfsV3Loader.java
@@ -84,6 +84,7 @@ public class GbfsV3Loader extends BaseGbfsLoader<GBFSFeed.Name, GBFSGbfs> {
 
     return feeds
       .stream()
+      .filter(feed -> !feed.getName().equals(GBFSFeed.Name.GBFS))
       .map(feed ->
         new GbfsFeed<>(
           feed.getName(),


### PR DESCRIPTION
For now, we don't update the discovery file. 