### PR TITLE
fix: log exception while mdc is still set

### DIFF
--- a/src/main/java/org/entur/gbfs/loader/GbfsSubscription.java
+++ b/src/main/java/org/entur/gbfs/loader/GbfsSubscription.java
@@ -5,5 +5,9 @@ public interface GbfsSubscription {
 
   boolean getSetupComplete();
 
+  void beforeUpdate();
+
   void update();
+
+  void afterUpdate();
 }

--- a/src/main/java/org/entur/gbfs/loader/v2/GbfsV2Subscription.java
+++ b/src/main/java/org/entur/gbfs/loader/v2/GbfsV2Subscription.java
@@ -95,41 +95,43 @@ public class GbfsV2Subscription implements GbfsSubscription {
     return loader.getSetupComplete();
   }
 
+  public void beforeUpdate() {
+    if (updateInterceptor != null) {
+      updateInterceptor.beforeUpdate();
+    }
+  }
+
   /**
    * Update the subscription by updating the loader and push a new delivery
    * to the consumer if the update had changes
    */
   public void update() {
-    if (updateInterceptor != null) {
-      updateInterceptor.beforeUpdate();
+    if (loader.update()) {
+      GbfsV2Delivery delivery = new GbfsV2Delivery(
+        loader.getDiscoveryFeed(),
+        loader.getFeed(GBFSGbfsVersions.class),
+        loader.getFeed(GBFSSystemInformation.class),
+        loader.getFeed(GBFSVehicleTypes.class),
+        loader.getFeed(GBFSStationInformation.class),
+        loader.getFeed(GBFSStationStatus.class),
+        loader.getFeed(GBFSFreeBikeStatus.class),
+        loader.getFeed(GBFSSystemHours.class),
+        loader.getFeed(GBFSSystemCalendar.class),
+        loader.getFeed(GBFSSystemRegions.class),
+        loader.getFeed(GBFSSystemPricingPlans.class),
+        loader.getFeed(GBFSSystemAlerts.class),
+        loader.getFeed(GBFSGeofencingZones.class),
+        Boolean.TRUE.equals(subscriptionOptions.enableValidation())
+          ? validateFeeds()
+          : null
+      );
+      consumer.accept(delivery);
     }
+  }
 
-    try {
-      if (loader.update()) {
-        GbfsV2Delivery delivery = new GbfsV2Delivery(
-          loader.getDiscoveryFeed(),
-          loader.getFeed(GBFSGbfsVersions.class),
-          loader.getFeed(GBFSSystemInformation.class),
-          loader.getFeed(GBFSVehicleTypes.class),
-          loader.getFeed(GBFSStationInformation.class),
-          loader.getFeed(GBFSStationStatus.class),
-          loader.getFeed(GBFSFreeBikeStatus.class),
-          loader.getFeed(GBFSSystemHours.class),
-          loader.getFeed(GBFSSystemCalendar.class),
-          loader.getFeed(GBFSSystemRegions.class),
-          loader.getFeed(GBFSSystemPricingPlans.class),
-          loader.getFeed(GBFSSystemAlerts.class),
-          loader.getFeed(GBFSGeofencingZones.class),
-          Boolean.TRUE.equals(subscriptionOptions.enableValidation())
-            ? validateFeeds()
-            : null
-        );
-        consumer.accept(delivery);
-      }
-    } finally {
-      if (updateInterceptor != null) {
-        updateInterceptor.afterUpdate();
-      }
+  public void afterUpdate() {
+    if (updateInterceptor != null) {
+      updateInterceptor.afterUpdate();
     }
   }
 

--- a/src/main/java/org/entur/gbfs/loader/v3/GbfsV3Subscription.java
+++ b/src/main/java/org/entur/gbfs/loader/v3/GbfsV3Subscription.java
@@ -92,6 +92,12 @@ public class GbfsV3Subscription implements GbfsSubscription {
     return loader.getSetupComplete();
   }
 
+  public void beforeUpdate() {
+    if (updateInterceptor != null) {
+      updateInterceptor.beforeUpdate();
+    }
+  }
+
   /**
    * Update the subscription by updating the loader and push a new delivery
    * to the consumer if the update had changes
@@ -101,30 +107,30 @@ public class GbfsV3Subscription implements GbfsSubscription {
       updateInterceptor.beforeUpdate();
     }
 
-    try {
-      if (loader.update()) {
-        GbfsV3Delivery delivery = new GbfsV3Delivery(
-          loader.getDiscoveryFeed(),
-          loader.getFeed(GBFSGbfsVersions.class),
-          loader.getFeed(GBFSSystemInformation.class),
-          loader.getFeed(GBFSVehicleTypes.class),
-          loader.getFeed(GBFSStationInformation.class),
-          loader.getFeed(GBFSStationStatus.class),
-          loader.getFeed(GBFSVehicleStatus.class),
-          loader.getFeed(GBFSSystemRegions.class),
-          loader.getFeed(GBFSSystemPricingPlans.class),
-          loader.getFeed(GBFSSystemAlerts.class),
-          loader.getFeed(GBFSGeofencingZones.class),
-          Boolean.TRUE.equals(subscriptionOptions.enableValidation())
-            ? validateFeeds()
-            : null
-        );
-        consumer.accept(delivery);
-      }
-    } finally {
-      if (updateInterceptor != null) {
-        updateInterceptor.afterUpdate();
-      }
+    if (loader.update()) {
+      GbfsV3Delivery delivery = new GbfsV3Delivery(
+        loader.getDiscoveryFeed(),
+        loader.getFeed(GBFSGbfsVersions.class),
+        loader.getFeed(GBFSSystemInformation.class),
+        loader.getFeed(GBFSVehicleTypes.class),
+        loader.getFeed(GBFSStationInformation.class),
+        loader.getFeed(GBFSStationStatus.class),
+        loader.getFeed(GBFSVehicleStatus.class),
+        loader.getFeed(GBFSSystemRegions.class),
+        loader.getFeed(GBFSSystemPricingPlans.class),
+        loader.getFeed(GBFSSystemAlerts.class),
+        loader.getFeed(GBFSGeofencingZones.class),
+        Boolean.TRUE.equals(subscriptionOptions.enableValidation())
+          ? validateFeeds()
+          : null
+      );
+      consumer.accept(delivery);
+    }
+  }
+
+  public void afterUpdate() {
+    if (updateInterceptor != null) {
+      updateInterceptor.afterUpdate();
     }
   }
 


### PR DESCRIPTION
This PR fixes the suggested `improve/mdc` PR, by assuring that a possible exception during update is logged before the `updateInterceptor.adterUpdate` is called.

Alternative soultion:
This solution is more complex than required and perhaps it would be sufficient, to log catch an exception in the GBFSSubscriptionVx update methods, log it, and only then call the updateInterceptor's `afterUpdate`.

In both cases, logging an exception is performed by the gbfs-loader-java classes, logging the rethrown exception from a calling ForkJoinPool's exception handler would replicate the same exception and not be required.