### PR TITLE
fix: log possible exceptions before afterUpdate call

### DIFF
--- a/src/main/java/org/entur/gbfs/loader/v2/GbfsV2Subscription.java
+++ b/src/main/java/org/entur/gbfs/loader/v2/GbfsV2Subscription.java
@@ -43,11 +43,15 @@ import org.mobilitydata.gbfs.v2_3.system_information.GBFSSystemInformation;
 import org.mobilitydata.gbfs.v2_3.system_pricing_plans.GBFSSystemPricingPlans;
 import org.mobilitydata.gbfs.v2_3.system_regions.GBFSSystemRegions;
 import org.mobilitydata.gbfs.v2_3.vehicle_types.GBFSVehicleTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class to represent a subscription to GBFS feeds for a single system
  */
 public class GbfsV2Subscription implements GbfsSubscription {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GbfsV2Subscription.class);
 
   private final GbfsSubscriptionOptions subscriptionOptions;
   private final Consumer<GbfsV2Delivery> consumer;
@@ -126,6 +130,9 @@ public class GbfsV2Subscription implements GbfsSubscription {
         );
         consumer.accept(delivery);
       }
+    } catch (RuntimeException e) {
+      LOG.error("Exception occurred during update", e);
+      throw e;
     } finally {
       if (updateInterceptor != null) {
         updateInterceptor.afterUpdate();

--- a/src/main/java/org/entur/gbfs/loader/v3/GbfsV3Subscription.java
+++ b/src/main/java/org/entur/gbfs/loader/v3/GbfsV3Subscription.java
@@ -41,11 +41,15 @@ import org.mobilitydata.gbfs.v3_0.system_pricing_plans.GBFSSystemPricingPlans;
 import org.mobilitydata.gbfs.v3_0.system_regions.GBFSSystemRegions;
 import org.mobilitydata.gbfs.v3_0.vehicle_status.GBFSVehicleStatus;
 import org.mobilitydata.gbfs.v3_0.vehicle_types.GBFSVehicleTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class to represent a subscription to GBFS feeds for a single system
  */
 public class GbfsV3Subscription implements GbfsSubscription {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GbfsV3Subscription.class);
 
   private final GbfsSubscriptionOptions subscriptionOptions;
   private final Consumer<GbfsV3Delivery> consumer;
@@ -121,6 +125,9 @@ public class GbfsV3Subscription implements GbfsSubscription {
         );
         consumer.accept(delivery);
       }
+    } catch (RuntimeException e) {
+      LOG.error("Exception occurred during update", e);
+      throw e;
     } finally {
       if (updateInterceptor != null) {
         updateInterceptor.afterUpdate();


### PR DESCRIPTION
This is an alternative to #183, without newly introduced lifecycle methods. Instead, possible exceptions are logged in the update context before `updateInterceptor.afterUpdate()` is called.