### PR TITLE
Add method to update a single subscription

### DIFF
--- a/src/main/java/org/entur/gbfs/GbfsSubscriptionManager.java
+++ b/src/main/java/org/entur/gbfs/GbfsSubscriptionManager.java
@@ -120,15 +120,28 @@ public class GbfsSubscriptionManager {
    * Update all subscriptions
    */
   public void update() {
-    subscriptions
-      .values()
-      .parallelStream()
-      .forEach(subscription ->
-        Optional
-          .ofNullable(customThreadPool)
-          .orElse(ForkJoinPool.commonPool())
-          .execute(subscription::update)
-      );
+    subscriptions.values().parallelStream().forEach(subscription -> update(subscription));
+  }
+
+  /**
+   * Update single subscription
+   *
+   * @param identifier Identifier of subscription
+   */
+  public void update(String identifier) {
+    update(subscriptions.get(identifier));
+  }
+
+  /**
+   * Update single subscription
+   *
+   * @param subscription Subscription which should be updated
+   */
+  private void update(GbfsSubscription subscription) {
+    Optional
+      .ofNullable(customThreadPool)
+      .orElse(ForkJoinPool.commonPool())
+      .execute(subscription::update);
   }
 
   /**


### PR DESCRIPTION
This PR adds new method, to update a single subscription.

Intended use is to let Lamassu update a subscription directly after successful registratation, instead of updating the complete set of subscriptions.