### PR TITLE
chore(deps): dependency sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,17 @@ jobs:
     env:
       TZ: Europe/Oslo
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # nodejs is needed because the dynamic download of it via the prettier maven plugin often
       # times out
       # Example: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/4490450225/jobs/7897533439
       - uses: actions/setup-node@v6
         with:
-          node-version: 18.20.8
+          node-version: 24.16.0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,15 +17,15 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 17.0.13
           distribution: liberica
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -51,7 +51,7 @@ jobs:
                   -Dsonar.host.url=https://sonarcloud.io \
                   -Dsonar.token=${SONAR_TOKEN}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           path: target/*.jar
   publish-release:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,14 +34,14 @@ jobs:
             ${{ runner.os }}-maven-
             ${{ runner.os }}-
       - name: Run maven build
-        run: mvn verify -s .github/workflows/settings.xml -Dprettier.nodePath=node -Dprettier.npmPath=npm
+        run: mvn verify -Dprettier.nodePath=node -Dprettier.npmPath=npm
       - name: Sonar Scan
         env:
           SONAR_TOKEN: ${{ secrets.ENTUR_SONAR_PASSWORD }}
           SONAR_PROJECT_NAME: ${{ github.event.repository.name }}
           SONAR_PROJECT_KEY: entur_${{ github.event.repository.name }}
         run: |
-          mvn -Psonar -s .github/workflows/settings.xml \
+          mvn -Psonar \
                   sonar:sonar \
                   -P prettierSkip \
                   -DskipTests \

--- a/pom.xml
+++ b/pom.xml
@@ -46,16 +46,16 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>17</jdk.version>
 
-        <gbfs-java-model.version>1.0.12</gbfs-java-model.version>
+        <gbfs-java-model.version>1.0.14</gbfs-java-model.version>
         <gbfs-validator-java.version>3.1.0</gbfs-validator-java.version>
-        <jackson-databind.version>2.21.2</jackson-databind.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <jackson-databind.version>2.22.0</jackson-databind.version>
+        <slf4j.version>2.0.18</slf4j.version>
         <httpclient-version>4.5.14</httpclient-version>
         <oauth2-essentials.version>0.22.1</oauth2-essentials.version>
-        <httpurlconnection-executor.version>0.21.3</httpurlconnection-executor.version>
+        <httpurlconnection-executor.version>1.22.1</httpurlconnection-executor.version>
         <maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+        <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
@@ -64,24 +64,24 @@
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
-        <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-        <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
+        <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
+        <maven-site-plugin.version>3.22.0</maven-site-plugin.version>
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
-        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+        <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <plexus-compiler-javac.version>2.16.2</plexus-compiler-javac.version>
         <dependency-check-maven.version>5.3.2</dependency-check-maven.version>
         <maven-scm-provider-gitexe.version>1.13.0</maven-scm-provider-gitexe.version>
         <maven-scm-api.version>1.13.0</maven-scm-api.version>
-        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
-        <jreleaser-maven-plugin.version>1.23.0</jreleaser-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
+        <jreleaser-maven-plugin.version>1.24.0</jreleaser-maven-plugin.version>
 
         <!-- empty argLine property, the value is set up by Jacoco during unit tests execution -->
         <argLine />
 
         <!-- Unit test frameworks versions -->
         <assertj.core.version>3.27.7</assertj.core.version>
-        <junit.version>5.14.3</junit.version>
+        <junit.version>5.14.4</junit.version>
 
         <!-- GPG configuration for jar signing-->
         <gpg.executable>gpg</gpg.executable>
@@ -166,9 +166,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
-            <version>2.35.2</version>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -180,7 +180,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>24.1.0</version>
+            <version>26.1.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/entur/gbfs/loader/v2/GbfsV2LoaderTest.java
+++ b/src/test/java/org/entur/gbfs/loader/v2/GbfsV2LoaderTest.java
@@ -8,7 +8,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.entur.gbfs.http.GBFSHttpClient;
 import org.junit.jupiter.api.Disabled;
@@ -29,7 +31,6 @@ import org.mobilitydata.gbfs.v2_3.vehicle_types.GBFSVehicleType;
 import org.mobilitydata.gbfs.v2_3.vehicle_types.GBFSVehicleTypes;
 import org.mobilitydata.gbfs.validation.GbfsValidator;
 import org.mobilitydata.gbfs.validation.GbfsValidatorFactory;
-import org.mobilitydata.gbfs.validation.model.FileValidationResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,12 +144,7 @@ class GbfsV2LoaderTest {
   private void validateV22Feed(GbfsV2Loader loader) {
     assertTrue(loader.update());
 
-    GbfsValidator validator = GbfsValidatorFactory.getGbfsJsonValidator();
-    FileValidationResult validationResult = validator.validateFile(
-      "system_information",
-      new ByteArrayInputStream(loader.getRawFeed(GBFSFeedName.SystemInformation).get())
-    );
-    assertEquals(0, validationResult.errorsCount());
+    assertFeedValidates(loader);
 
     assertFalse(loader.getRawFeed(GBFSFeedName.GBFS).isEmpty());
 
@@ -164,13 +160,6 @@ class GbfsV2LoaderTest {
     assertNull(systemInformation.getData().getShortName());
     assertNull(systemInformation.getData().getUrl());
 
-    validationResult =
-      validator.validateFile(
-        "vehicle_types",
-        new ByteArrayInputStream(loader.getRawFeed(GBFSFeedName.VehicleTypes).get())
-      );
-    assertEquals(0, validationResult.errorsCount());
-
     GBFSVehicleTypes vehicleTypes = loader.getFeed(GBFSVehicleTypes.class);
     assertNotNull(vehicleTypes);
     assertEquals(1, vehicleTypes.getData().getVehicleTypes().size());
@@ -179,13 +168,6 @@ class GbfsV2LoaderTest {
     assertEquals(GBFSVehicleType.FormFactor.BICYCLE, vehicleType.getFormFactor());
     assertEquals(GBFSVehicleType.PropulsionType.HUMAN, vehicleType.getPropulsionType());
     assertNull(vehicleType.getMaxRangeMeters());
-
-    validationResult =
-      validator.validateFile(
-        "station_information",
-        new ByteArrayInputStream(loader.getRawFeed(GBFSFeedName.StationInformation).get())
-      );
-    assertEquals(0, validationResult.errorsCount());
 
     GBFSStationInformation stationInformation = loader.getFeed(
       GBFSStationInformation.class
@@ -197,13 +179,6 @@ class GbfsV2LoaderTest {
       stations.stream().anyMatch(gbfsStation -> gbfsStation.getName().equals("TORVGATA"))
     );
     assertEquals(21, stations.stream().mapToDouble(GBFSStation::getCapacity).sum());
-
-    validationResult =
-      validator.validateFile(
-        "station_status",
-        new ByteArrayInputStream(loader.getRawFeed(GBFSFeedName.StationStatus).get())
-      );
-    assertEquals(0, validationResult.errorsCount());
 
     GBFSStationStatus stationStatus = loader.getFeed(GBFSStationStatus.class);
     assertNotNull(stationStatus);
@@ -217,13 +192,6 @@ class GbfsV2LoaderTest {
     assertNull(loader.getFeed(GBFSSystemCalendar.class));
     assertNull(loader.getFeed(GBFSSystemRegions.class));
 
-    validationResult =
-      validator.validateFile(
-        "system_pricing_plans",
-        new ByteArrayInputStream(loader.getRawFeed(GBFSFeedName.SystemPricingPlans).get())
-      );
-    assertEquals(0, validationResult.errorsCount());
-
     GBFSSystemPricingPlans pricingPlans = loader.getFeed(GBFSSystemPricingPlans.class);
 
     assertNotNull(pricingPlans);
@@ -235,12 +203,7 @@ class GbfsV2LoaderTest {
   private void validateV10Feed(GbfsV2Loader loader) {
     assertTrue(loader.update());
 
-    GbfsValidator validator = GbfsValidatorFactory.getGbfsJsonValidator();
-    FileValidationResult validationResult = validator.validateFile(
-      "system_information",
-      new ByteArrayInputStream(loader.getRawFeed(GBFSFeedName.SystemInformation).get())
-    );
-    assertEquals(0, validationResult.errorsCount());
+    assertFeedValidates(loader);
 
     GBFSSystemInformation systemInformation = loader.getFeed(GBFSSystemInformation.class);
     assertNotNull(systemInformation);
@@ -256,13 +219,6 @@ class GbfsV2LoaderTest {
 
     assertNull(loader.getFeed(GBFSVehicleTypes.class));
 
-    validationResult =
-      validator.validateFile(
-        "station_information",
-        new ByteArrayInputStream(loader.getRawFeed(GBFSFeedName.StationInformation).get())
-      );
-    assertEquals(0, validationResult.errorsCount());
-
     GBFSStationInformation stationInformation = loader.getFeed(
       GBFSStationInformation.class
     );
@@ -275,13 +231,6 @@ class GbfsV2LoaderTest {
         .anyMatch(gbfsStation -> gbfsStation.getName().equals("Kaivopuisto"))
     );
     assertEquals(239, stations.stream().mapToDouble(GBFSStation::getCapacity).sum());
-
-    validationResult =
-      validator.validateFile(
-        "station_status",
-        new ByteArrayInputStream(loader.getRawFeed(GBFSFeedName.StationStatus).get())
-      );
-    assertEquals(0, validationResult.errorsCount());
 
     GBFSStationStatus stationStatus = loader.getFeed(GBFSStationStatus.class);
     assertNotNull(stationStatus);
@@ -306,5 +255,21 @@ class GbfsV2LoaderTest {
     assertNull(loader.getFeed(GBFSSystemRegions.class));
     assertNull(loader.getFeed(GBFSSystemPricingPlans.class));
     assertNull(loader.getFeed(GBFSGeofencingZones.class));
+  }
+
+  /**
+   * Validates the feed as a whole rather than file-by-file. The validator resolves
+   * cross-file references (e.g. vehicle_type_id, station_id), so validating individual
+   * files in isolation reports spurious "not a valid enum value" errors.
+   */
+  private void assertFeedValidates(GbfsV2Loader loader) {
+    Map<String, InputStream> feeds = new HashMap<>();
+    for (GBFSFeedName name : GBFSFeedName.values()) {
+      loader
+        .getRawFeed(name)
+        .ifPresent(bytes -> feeds.put(name.value(), new ByteArrayInputStream(bytes)));
+    }
+    GbfsValidator validator = GbfsValidatorFactory.getGbfsJsonValidator();
+    assertEquals(0, validator.validate(feeds).summary().errorsCount());
   }
 }

--- a/src/test/java/org/entur/gbfs/loader/v3/GbfsV3LoaderTest.java
+++ b/src/test/java/org/entur/gbfs/loader/v3/GbfsV3LoaderTest.java
@@ -3,7 +3,10 @@ package org.entur.gbfs.loader.v3;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mobilitydata.gbfs.v3_0.gbfs.GBFSFeed;
 import org.mobilitydata.gbfs.v3_0.geofencing_zones.GBFSGeofencingZones;
@@ -15,7 +18,6 @@ import org.mobilitydata.gbfs.v3_0.vehicle_types.GBFSVehicleType;
 import org.mobilitydata.gbfs.v3_0.vehicle_types.GBFSVehicleTypes;
 import org.mobilitydata.gbfs.validation.GbfsValidator;
 import org.mobilitydata.gbfs.validation.GbfsValidatorFactory;
-import org.mobilitydata.gbfs.validation.model.FileValidationResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,12 +42,7 @@ class GbfsV3LoaderTest {
   private void validateV3Feed(GbfsV3Loader loader) {
     assertTrue(loader.update());
 
-    GbfsValidator validator = GbfsValidatorFactory.getGbfsJsonValidator();
-    FileValidationResult validationResult = validator.validateFile(
-      "system_information",
-      new ByteArrayInputStream(loader.getRawFeed(GBFSFeed.Name.SYSTEM_INFORMATION).get())
-    );
-    assertEquals(0, validationResult.errorsCount());
+    assertFeedValidates(loader);
 
     assertFalse(loader.getRawFeed(GBFSFeed.Name.GBFS).isEmpty());
 
@@ -64,13 +61,6 @@ class GbfsV3LoaderTest {
       systemInformation.getData().getUrl()
     );
 
-    validationResult =
-      validator.validateFile(
-        "vehicle_types",
-        new ByteArrayInputStream(loader.getRawFeed(GBFSFeed.Name.VEHICLE_TYPES).get())
-      );
-    assertEquals(0, validationResult.errorsCount());
-
     GBFSVehicleTypes vehicleTypes = loader.getFeed(GBFSVehicleTypes.class);
     assertNotNull(vehicleTypes);
     assertEquals(4, vehicleTypes.getData().getVehicleTypes().size());
@@ -86,13 +76,6 @@ class GbfsV3LoaderTest {
     );
     assertEquals(400000, vehicleType.getMaxRangeMeters());
 
-    validationResult =
-      validator.validateFile(
-        "vehicle_status",
-        new ByteArrayInputStream(loader.getRawFeed(GBFSFeed.Name.VEHICLE_STATUS).get())
-      );
-    assertEquals(0, validationResult.errorsCount());
-
     GBFSVehicleStatus vehicleStatus = loader.getFeed(GBFSVehicleStatus.class);
     assertNotNull(vehicleStatus);
     List<GBFSVehicle> vecicles = vehicleStatus.getData().getVehicles();
@@ -103,21 +86,28 @@ class GbfsV3LoaderTest {
         .anyMatch(vehicle -> vehicle.getVehicleId().equals("YGA:Vehicle:1218349"))
     );
 
-    validationResult =
-      validator.validateFile(
-        "system_pricing_plans",
-        new ByteArrayInputStream(
-          loader.getRawFeed(GBFSFeed.Name.SYSTEM_PRICING_PLANS).get()
-        )
-      );
-    assertEquals(0, validationResult.errorsCount());
-
     GBFSSystemPricingPlans pricingPlans = loader.getFeed(GBFSSystemPricingPlans.class);
 
     assertNotNull(pricingPlans);
     assertEquals(40, pricingPlans.getData().getPlans().size());
 
     assertNull(loader.getFeed(GBFSGeofencingZones.class));
+  }
+
+  /**
+   * Validates the feed as a whole rather than file-by-file. The validator resolves
+   * cross-file references (e.g. vehicle_type_id, pricing_plan_id), so validating
+   * individual files in isolation reports spurious "not a valid enum value" errors.
+   */
+  private void assertFeedValidates(GbfsV3Loader loader) {
+    Map<String, InputStream> feeds = new HashMap<>();
+    for (GBFSFeed.Name name : GBFSFeed.Name.values()) {
+      loader
+        .getRawFeed(name)
+        .ifPresent(bytes -> feeds.put(name.value(), new ByteArrayInputStream(bytes)));
+    }
+    GbfsValidator validator = GbfsValidatorFactory.getGbfsJsonValidator();
+    assertEquals(0, validator.validate(feeds).summary().errorsCount());
   }
 
   @Test


### PR DESCRIPTION
Consolidates several Renovate dependency PRs into one sweep. Built and tested locally under JDK 17 (the CI JDK): full `mvn verify` is green with prettier check passing.

## Included

**Java dependencies**
- `gbfs-java-model` 1.0.12 → 1.0.14 (#261)
- `jackson-databind` 2.21.2 → 2.22.0 (#261)
- `slf4j` 1.7.36 → 2.0.18 (#147)
- dmfs `httpurlconnection-executor` 0.21.3 → 1.22.1 (#148)
- `org.jetbrains:annotations` 24.1.0 → 26.1.0 (#188)
- `junit` 5.14.3 → 5.14.4 (#261)
- test: migrate `com.github.tomakehurst:wiremock-jre8` 2.35.2 (EOL) → `org.wiremock:wiremock` 3.0.1 (#206)

**Build plugins**
- `maven-surefire-plugin` 2.22.2 → 3.5.6 (#144)
- `maven-install-plugin` 2.5.2 → 3.1.4 (#143)
- `maven-deploy-plugin` 2.8.2 → 3.1.4 (#141)
- `maven-enforcer-plugin` 3.6.2 → 3.6.3, `maven-site-plugin` 3.21.0 → 3.22.0, `jacoco` 0.8.14 → 0.8.15, `jreleaser` 1.23.0 → 1.24.0 (#261)

**GitHub Actions**
- `actions/checkout` v4 → v6 (#250), `actions/setup-java` v3/v4 → v5 (#231), `actions/cache` v4 → v5 (#252), `actions/upload-artifact` v4.6.2 → v7.0.1 (#243), node 18.20.8 → 24.16.0 (#245)

## ⚠️ Notable finding: the test suite was not running in CI

`maven-surefire-plugin` 2.22.2 is too old to discover the JUnit 5.14 Jupiter tests — it silently ran **0 tests** while reporting success (verified on the latest master CI run). The surefire 3.x bump makes the suite run again (**30 tests**).

That surfaced a pre-existing problem: the loader tests validated each feed file **in isolation**. `gbfs-validator-java` 3.1.0 (adopted on master in #264) resolves cross-file references — `vehicle_type_id`, `pricing_plan_id`, `station_id` — so isolated single-file validation reports spurious "not a valid enum value" errors. Fixed by validating the feed as a whole (matching the pattern already used in `GBFSSubscriptionTest`). The feed data itself is valid.

## Deliberately held out (separate PRs)
- **junit 6** (#239) — major test-framework jump, deserves isolated verification
- **dependency-check-maven** 5 → 12 (#146) — very large jump, scan-only plugin
- **wagon-ssh-external** 2 → 3 (#145) — release-path only and effectively vestigial (deploy goes through `entur/gha-maven-central`)
- **pin dependencies** (#262) — conflicts with the GitHub Actions major bumps above; pinning is a separate policy decision

Renovate should auto-close the included PRs once this merges.