### PR TITLE
chore: remove unused wagon-ssh-external build extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,15 +185,6 @@
         </dependency>
     </dependencies>
     <build>
-        <extensions>
-            <!-- maven3 will need wagon-ssh extension in order to be able to release,
-            Using external variant in order to retain keys, etc -->
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-ssh-external</artifactId>
-                <version>2.12</version>
-            </extension>
-        </extensions>
         <pluginManagement>
             <plugins>
                 <plugin>


### PR DESCRIPTION
Follow-up to the dependency sweep (#265). The `wagon-ssh-external` extension was held out of that sweep because it's release-path related; on closer inspection it's unused and can be dropped entirely rather than bumped.

## Why it's safe to remove
`wagon-ssh-external` only provides the `scp://`/`sftp://` transport for `mvn deploy`, needed only when a `distributionManagement` URL uses an `scp://` scheme. In this repo:

- The only `distributionManagement` repo is the snapshot repo on an **`https://`** URL (default http wagon handles it).
- Releases to Maven Central go through `entur/gha-maven-central` + jreleaser, deploying from the `publication` profile's local `target/staging-deploy` directory — no scp.
- The only `ssh://` references in the pom are the **git SCM** connection (`scm:git:ssh://…`), which uses the git client, not a maven wagon.

The accompanying comment ("maven3 will need wagon-ssh extension in order to be able to release") dates from the old `release:perform`-over-scp-to-jfrog workflow.

## Verification (locally, JDK 17)
- `mvn clean verify` → green, 30 tests.
- `mvn -Ppublication clean deploy` → successfully deploys the pom/jar/sources/javadoc to `target/staging-deploy` via the `file:` repo, with no wagon/scp involvement.