### PR TITLE
chore: remove unused dependency-check-maven plugin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,6 @@ env:
     SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
     SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
     SONATYPE_GPG_KEY_PASSWORD: ${{ secrets.SONATYPE_GPG_KEY_PASSWORD }}
-    NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
 jobs:
   maven-package:
     if: "!contains(github.event.head_commit.message, 'ci skip')"

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <plexus-compiler-javac.version>2.16.2</plexus-compiler-javac.version>
-        <dependency-check-maven.version>5.3.2</dependency-check-maven.version>
         <maven-scm-provider-gitexe.version>1.13.0</maven-scm-provider-gitexe.version>
         <maven-scm-api.version>1.13.0</maven-scm-api.version>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
@@ -320,11 +319,6 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>${versions-maven-plugin.version}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>${dependency-check-maven.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.jreleaser</groupId>


### PR DESCRIPTION
The `org.owasp:dependency-check-maven` plugin was declared with **no `<executions>`**, so it was never bound to a lifecycle phase and never ran during `mvn verify` or anywhere in CI — dead configuration.

This removes:
- the plugin declaration and its `dependency-check-maven.version` property;
- the now-unused `NVD_API_KEY` env var from `deploy.yml`.

This is why the related Renovate PR (#146, bump 5→12) was closed rather than merged: bumping a plugin that never runs adds no value, and 5.x is non-functional against today's NVD API anyway.

If OWASP dependency scanning is wanted later, it should be re-added with a current version **and** explicitly wired into CI.

Verified locally under JDK 17: `mvn clean verify` green (30 tests).