### PR TITLE
chore(deps): update junit to v6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
         <!-- Unit test frameworks versions -->
         <assertj.core.version>3.27.7</assertj.core.version>
-        <junit.version>5.14.4</junit.version>
+        <junit.version>6.1.0</junit.version>
 
         <!-- GPG configuration for jar signing-->
         <gpg.executable>gpg</gpg.executable>


### PR DESCRIPTION
Bumps the JUnit monorepo `5.14.4` → `6.1.0` (junit-jupiter + junit-platform). Replaces Renovate PR #239.

JUnit 6 requires a Java 17 baseline — already this project's target.

Held out of the dependency sweep (#265) as a major test-framework jump. It's verifiable now because the surefire 3.x bump in that sweep made the test suite actually execute (it had silently run zero tests under surefire 2.22.2).

Verified locally under JDK 17: `mvn clean verify` green — all **30 tests** pass with surefire 3.5.6 + junit-platform 6.1.0, no compatibility issues.